### PR TITLE
Change how confirmUrl is generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 db/
+node_modules

--- a/api.js
+++ b/api.js
@@ -59,7 +59,7 @@ API.prototype.signup = function (req, res, opts, cb) {
         urlObj.hash = ''
         urlObj.query.confirmToken = user.data.confirmToken
         urlObj.query.email = email
-        confirmUrl = URL.format(urlObj) + '/' + (hash || '')
+        confirmUrl = URL.format(urlObj) + hash ? ('/' + hash) : ''
       }
 
       var emailOpts = {}
@@ -170,7 +170,7 @@ API.prototype.changePasswordRequest = function (req, res, opts, cb) {
         urlObj.hash = ''
         urlObj.query.changeToken = changeToken
         urlObj.query.email = email
-        changeUrl = URL.format(urlObj) + '/' + (hash || '')
+        changeUrl = URL.format(urlObj) + hash ? ('/' + hash) : ''
       }
 
       var emailOpts = {}
@@ -215,7 +215,7 @@ API.prototype.changePassword = function (req, res, opts, cb) {
 
         var authToken = self.Tokens.encode(email)
 
-        res.writeHead(200, {'Content-Type': 'application/json'})
+        res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({
           success: true,
           message: 'Password changed.',

--- a/api.js
+++ b/api.js
@@ -55,9 +55,11 @@ API.prototype.signup = function (req, res, opts, cb) {
 
       if (confirmUrl) {
         var urlObj = URL.parse(confirmUrl, true)
+        var hash = urlObj.hash
+        urlObj.hash = ''
         urlObj.query.confirmToken = user.data.confirmToken
         urlObj.query.email = email
-        confirmUrl = URL.format(urlObj)
+        confirmUrl = URL.format(urlObj) + '/' + (hash || '')
       }
 
       var emailOpts = {}
@@ -164,9 +166,11 @@ API.prototype.changePasswordRequest = function (req, res, opts, cb) {
 
       if (changeUrl) {
         var urlObj = URL.parse(changeUrl, true)
+        var hash = urlObj.hash
+        urlObj.hash = ''
         urlObj.query.changeToken = changeToken
         urlObj.query.email = email
-        changeUrl = URL.format(urlObj)
+        changeUrl = URL.format(urlObj) + '/' + (hash || '')
       }
 
       var emailOpts = {}


### PR DESCRIPTION
This temporary saves provided service's conrifmUrl hash part to variable, and appends it back (if there was a hash) after the urls (confirmUrl, changePasswordUrl) are composed.